### PR TITLE
bugfix: use remediation only when occurrence count match

### DIFF
--- a/handlers/remediation/sensu.rb
+++ b/handlers/remediation/sensu.rb
@@ -119,12 +119,14 @@ class Remediator < Sensu::Handler
           range = Range.new($~.to_a[1].to_i, 9999).to_a
           next unless range.include?(occurrences)
         end
+
+        # Check remediations matching the current severity
+        next unless (conditions["severities"] || []).include?(severity)
+
+        remediations_to_trigger << check
+
       end
 
-      # Check remediations matching the current severity
-      next unless (conditions["severities"] || []).include?(severity)
-
-      remediations_to_trigger << check
     end
     remediations_to_trigger
   end


### PR DESCRIPTION
There's a subtle bug with this code.

The way the algorithm works now is wrong: whichever is the current count of occurrences, if you have a remediation for the current `severity` you get that remediation triggered, despite of what that remediation's occurrences configuration is.

If you take a close look, all of the `next unless` statements inside the `(conditions["occurrences"] || []).each do |value|` block are the last statements in that `.each`, so they effectively do nothing (wether the condition is true or false always yields the same result: you start again at the top of that .each in a new iteration).

What should happen is, being any of the conditions true, such as `value.is_a?(Integer)` and then `occurrences == value`, the algorithm should continue to check if the severity matches (with the `next unless (conditions["severities"] || []).include?(severity)` statement, and then add the remediation to `remediations_to_trigger`).
